### PR TITLE
Make has_field_access decorator preserve func name

### DIFF
--- a/graphene_field_permission/decorators.py
+++ b/graphene_field_permission/decorators.py
@@ -1,4 +1,5 @@
 import logging
+from functools import wraps
 from . import api
 
 logger = logging.getLogger(__name__)
@@ -10,6 +11,7 @@ class has_field_access:
         self.req_perms = req_perms
 
     def __call__(self, func, *args, **kwargs):
+        @wraps(func)
         def check(data, info, *args, **kwargs):
             try:
                 api.check_field_access(


### PR DESCRIPTION
Use functools.wraps to keep the original func name wrapped by has_field_access decorator. It is useful if you want to chain decorators to require permissions with logical AND rather than logical OR